### PR TITLE
Pool nodes as a doubly-linked list

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -45,6 +45,26 @@ func (p *Pool) Add(ns Namespace) {
 	s.Link(r)
 }
 
+// Drop .
+func (p *Pool) Drop(domain string) error {
+	for i := 0; i < p.Nodes.Len(); i++ {
+		ns, ok := p.Nodes.Value.(Namespace)
+		if !ok {
+			return errors.New("Could not typecast Ring.Value to Namespace")
+		}
+
+		if ns.Domain == domain {
+			prev := p.Nodes.Prev()
+			next := p.Nodes.Next()
+			prev.Link(next)
+			p.Nodes = prev
+		}
+
+		p.Nodes = p.Nodes.Next()
+	}
+	return nil
+}
+
 // Next .
 func (p *Pool) Next() Namespace {
 	switch p.Strategy {

--- a/pool.go
+++ b/pool.go
@@ -38,6 +38,13 @@ func (p *Pool) SetStrategy(strategy Strategy) error {
 	return nil
 }
 
+// Add .
+func (p *Pool) Add(ns Namespace) {
+	s := &ring.Ring{Value: ns}
+	r := p.Nodes.Link(s)
+	s.Link(r)
+}
+
 // Next .
 func (p *Pool) Next() Namespace {
 	switch p.Strategy {

--- a/pool.go
+++ b/pool.go
@@ -57,6 +57,7 @@ func (p *Pool) Drop(domain string) error {
 			prev := p.Nodes.Prev()
 			next := p.Nodes.Next()
 			prev.Link(next)
+			p.Nodes = nil
 			p.Nodes = prev
 		}
 

--- a/pool_test.go
+++ b/pool_test.go
@@ -2,39 +2,43 @@ package fireload
 
 import "testing"
 
-func testPool() *Pool {
-	nodes := []*Namespace{
-		{Domain: "node-1"},
-		{Domain: "node-2"},
-		{Domain: "node-3"},
-	}
-	p, _ := NewPool(nodes)
-	return p
+var testNodes = []Namespace{
+	{Domain: "node-1.firebaseio.com"},
+	{Domain: "node-2.firebaseio.com"},
+	{Domain: "node-3.firebaseio.com"},
+	{Domain: "node-4.firebaseio.com"},
+	{Domain: "node-5.firebaseio.com"},
 }
 
 func Test_NewPool(t *testing.T) {
-	p := testPool()
-
-	if p == nil {
-		t.Fail()
-	}
-}
-
-func Test_NewPool_NilPointer(t *testing.T) {
-	nodes := []*Namespace{
-		{Domain: "node-1"},
-		{Domain: "node-2"},
-		{Domain: "node-3"},
-		nil,
+	p, err := NewPool(testNodes...)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	if _, err := NewPool(nodes); err != ErrNilPointer {
-		t.Fatalf("Expected NewPool with nil pointer to return %s but got %v", ErrNilPointer, err)
+	seen := map[string]int{}
+	for i := 0; i < p.Nodes.Len(); i++ {
+		val := p.Nodes.Value
+		ns, ok := val.(Namespace)
+		if !ok {
+			t.Fatalf("Expected p.Nodes to be a Ring with Namespace values. Got %T", val)
+		}
+		seen[ns.Domain]++
+		p.Nodes = p.Nodes.Next()
+	}
+
+	for domain, count := range seen {
+		if count != 1 {
+			t.Fatalf("Expected to see %s once, but saw it %d times", domain, count)
+		}
 	}
 }
 
 func Test_Pool_DefaultStrategy(t *testing.T) {
-	p := testPool()
+	p, err := NewPool(testNodes...)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if p.Strategy != StrategyRandom {
 		t.Fatalf("Expected default strategy to be %d but got %d", StrategyRandom, p.Strategy)
@@ -42,7 +46,10 @@ func Test_Pool_DefaultStrategy(t *testing.T) {
 }
 
 func Test_Pool_SetStrategy(t *testing.T) {
-	p := testPool()
+	p, err := NewPool(testNodes...)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := p.SetStrategy(StrategyRoundRobin); err != nil {
 		t.Fatal(err)
 	}
@@ -53,67 +60,88 @@ func Test_Pool_SetStrategy(t *testing.T) {
 }
 
 func Test_Pool_SetStrategy_Invalid(t *testing.T) {
-	p := testPool()
+	p, err := NewPool(testNodes...)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if err := p.SetStrategy(Strategy(-1)); err != ErrInvalidStrategy {
-		t.Fatalf("Expected SetStrategy with invalid strategy to return %s but got %v", ErrNilPointer, err)
+		t.Fatalf("Expected SetStrategy with invalid strategy to return %s but got %v", ErrInvalidStrategy, err)
 	}
 }
 
 func Test_Pool_NextRandom(t *testing.T) {
-	p := testPool()
+	p, err := NewPool(testNodes...)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	for i := 0; i <= 3*len(p.Nodes); i++ {
-		if got := p.NextRandom(); got == nil {
-			t.Fatalf("Expected NextRandom() not to yield a nil pointer")
+	for i := 0; i <= 2*p.Nodes.Len(); i++ {
+		next := p.NextRandom()
+		if next.Domain == "" {
+			t.Fatalf("Expected NextRandom() not to yield nil value Namespace")
 		}
 	}
 }
 
 func Test_Pool_Next_StrategyRandom(t *testing.T) {
-	p := testPool()
+	p, err := NewPool(testNodes...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if err := p.SetStrategy(StrategyRandom); err != nil {
 		t.Fatal(err)
 	}
 
-	for i := 0; i <= 3*len(p.Nodes); i++ {
-		if got := p.Next(); got == nil {
-			t.Fatalf("Expected Next() not to yield a nil pointer")
+	for i := 0; i <= 2*p.Nodes.Len(); i++ {
+		if got := p.Next(); got.Domain == "" {
+			t.Fatalf("Expected Next() not to yield nil value Namespace")
 		}
 	}
 }
 
 func Test_Pool_NextRoundRobin(t *testing.T) {
-	p := testPool()
+	p, err := NewPool(testNodes...)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	for i := 0; i <= 3; i++ {
-		for j, expected := range p.Nodes {
-			if got := p.NextRoundRobin(); got != expected {
-				t.Fatalf("Expected NextRoundRobin() to yield %v but got %v", expected, got)
-			}
+	for i := 0; i <= 2*p.Nodes.Len(); i++ {
+		node := p.Nodes.Next()
 
-			if p.lastIndex != j {
-				t.Fatalf("Expected NextRoundRobin() to update lastIndex to %d, but got %d", j, p.lastIndex)
-			}
+		expected, ok := node.Value.(Namespace)
+		if !ok {
+			t.Fatalf("Couldn't typecast %v as Namesapce", node.Value)
 		}
+
+		if got := p.NextRoundRobin(); got.String() != expected.String() {
+			t.Fatalf("Expected NextRoundRobin() to yield %v but got %v", expected, got)
+		}
+
 	}
 }
 
 func Test_Pool_Next_StrategyRoundRobin(t *testing.T) {
-	p := testPool()
+	p, err := NewPool(testNodes...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if err := p.SetStrategy(StrategyRoundRobin); err != nil {
 		t.Fatal(err)
 	}
 
-	for i := 0; i <= 3; i++ {
-		for j, expected := range p.Nodes {
-			if got := p.Next(); got != expected {
-				t.Fatalf("Expected Next() to yield %v but got %v", expected, got)
-			}
+	for i := 0; i <= 2*p.Nodes.Len(); i++ {
+		node := p.Nodes.Next()
 
-			if p.lastIndex != j {
-				t.Fatalf("Expected Next() to update lastIndex to %d, but got %d", j, p.lastIndex)
-			}
+		expected, ok := node.Value.(Namespace)
+		if !ok {
+			t.Fatalf("Couldn't typecast %v as Namesapce", node.Value)
+		}
+
+		if got := p.Next(); got.String() != expected.String() {
+			t.Fatalf("Expected Next() to yield %v but got %v", expected, got)
 		}
 	}
 }

--- a/pool_test.go
+++ b/pool_test.go
@@ -38,7 +38,9 @@ func assertSeenSet(t *testing.T, nodes *ring.Ring, expected []Namespace) {
 
 	for _, ns := range expected {
 		if _, ok := seen[ns.Domain]; !ok {
-			t.Fatalf("Expected nodes to contain %s.\n\n%# v", ns.Domain, pretty.Formatter(seen))
+			t.Logf("Expected: %# v", pretty.Formatter(expected))
+			t.Logf("Saw: %# v", pretty.Formatter(seen))
+			t.Fatalf("Missing %s.", ns.Domain)
 		}
 
 		seen[ns.Domain]--
@@ -97,6 +99,32 @@ func Test_Pool_Add_Pass(t *testing.T) {
 	p.Add(newNS)
 
 	assertSeenSet(t, p.Nodes, append(testNodes, newNS))
+}
+
+func Test_Pool_Drop_Pass(t *testing.T) {
+	p, err := NewPool(testNodes...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.Drop("node-1.firebaseio.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	assertSeenSet(t, p.Nodes, testNodes[1:])
+}
+
+func Test_Pool_Drop_Pass_NodeDoesntExist(t *testing.T) {
+	p, err := NewPool(testNodes...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.Drop("node-nope.firebaseio.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	assertSeenSet(t, p.Nodes, testNodes)
 }
 
 func Test_Pool_NextRandom(t *testing.T) {


### PR DESCRIPTION
- [x] use `container/ring` instead of `[]*Namespace` for `Pool.Nodes` (#resolves #4)
- [x] return `Namespace` values instead of `*Namespace` pointers
- [x] variadic args in `NewPool()` (#resolves #3)
- [x] `func (p *Pool) Add(Namespace)`
- [x] `func (p *Pool) Drop(string) error`
